### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/axetroy/vscode-external.git"
+    "url": "https://github.com/axetroy/vscode-external.git"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Do not use `git+https` in `url`, that breaks VisualStudio Code open link* + it seems [not standard](https://docs.npmjs.com/files/package.json#repository).

If you click on `Repository` button in plugin page, it raises an error `Unable to open 'vscode-external.git': resource is not available.`